### PR TITLE
Stabilize acceptance eunit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: erlang
 otp_release:
 - 17.4
 before_install:
-    - curl -L -o /tmp/0.5.0_linux_amd64.zip https://dl.bintray.com/mitchellh/consul/0.5.0_linux_amd64.zip
+    - curl -L -o /tmp/0.5.0_linux_amd64.zip https://releases.hashicorp.com/consul/0.5.0/consul_0.5.0_linux_amd64.zip
     - unzip /tmp/0.5.0_linux_amd64.zip
     - ./consul agent -config-file consul-test.json > /tmp/consul.log &
 script: make test

--- a/test/conserl_acceptance_tests.erl
+++ b/test/conserl_acceptance_tests.erl
@@ -6,14 +6,14 @@
 
 simple_kv_put_get_test() ->
   application:ensure_all_started(conserl),
-  Key = binary_to_list(uuid:v4()),
-  Value = binary_to_list(uuid:v4()),
+  Key = uuid:to_string(uuid:v4()),
+  Value = uuid:to_string(uuid:v4()),
   conserl_kv:put(Key, Value),
   {ok, Response} = conserl_kv:get(Key),
   ?assertEqual(Value, maps:get(value, Response)).
 
 simple_kv_get_not_found_test() ->
-  Key = binary_to_list(uuid:v4()),
+  Key = uuid:to_string(uuid:v4()),
   ?assertEqual({error, "Not Found"}, conserl_kv:get(Key)).
 
 


### PR DESCRIPTION
Use text representation of UUIDs to ensure valid URLs. For example:
http://localhost:8500/v1/kv/6d0ddb6c-1c6a-4954-baf8-e1848ed643cd instead
of http://localhost:8500/v1/kv/%2FÃÄÆ^QAXü¾í^Zåß^D